### PR TITLE
feat: Render config for loh and somatic variants

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -14,7 +14,7 @@ module dna_seq_varlociraptor:
 
 use rule * from dna_seq_varlociraptor
 
-
+# Remove loh-events in case no normal sample is present
 if "normal" not in dna_seq_varlociraptor.samples["alias"].unique():
     list_keys = list(
         dna_seq_varlociraptor.config["calling"]["fdr-control"]["events"].keys()

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -15,11 +15,7 @@ module dna_seq_varlociraptor:
 use rule * from dna_seq_varlociraptor
 
 
-if "normal" not in dna_seq_varlociraptor.samples["alias"]:
-    del dna_seq_varlociraptor.config["calling"]["fdr-control"]["events"][
-        "loh_or_amplification"
-    ]
-else:
+if "normal"  in dna_seq_varlociraptor.samples["alias"]:
     tissue_counts = dna_seq_varlociraptor.samples.groupby("alias").size()
     if tissue_counts["normal"] != tissue_counts["tumor"]:
         raise WorkflowError(

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -14,10 +14,13 @@ module dna_seq_varlociraptor:
 
 use rule * from dna_seq_varlociraptor
 
+
 if "normal" not in dna_seq_varlociraptor.samples["alias"].unique():
-    list_keys = list(dna_seq_varlociraptor.config["calling"]["fdr-control"]["events"].keys())
+    list_keys = list(
+        dna_seq_varlociraptor.config["calling"]["fdr-control"]["events"].keys()
+    )
     for k in list_keys:
-        if k.startswith('loh'):
+        if k.startswith("loh"):
             dna_seq_varlociraptor.config["calling"]["fdr-control"]["events"].pop(k)
 else:
     tissue_counts = dna_seq_varlociraptor.samples.groupby("alias").size()

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -14,6 +14,7 @@ module dna_seq_varlociraptor:
 
 use rule * from dna_seq_varlociraptor
 
+
 # Remove loh-events in case no normal sample is present
 if "normal" not in dna_seq_varlociraptor.samples["alias"].unique():
     list_keys = list(

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -14,8 +14,12 @@ module dna_seq_varlociraptor:
 
 use rule * from dna_seq_varlociraptor
 
-
-if "normal"  in dna_seq_varlociraptor.samples["alias"]:
+if "normal" not in dna_seq_varlociraptor.samples["alias"].unique():
+    list_keys = list(dna_seq_varlociraptor.config["calling"]["fdr-control"]["events"].keys())
+    for k in list_keys:
+        if k.startswith('loh'):
+            dna_seq_varlociraptor.config["calling"]["fdr-control"]["events"].pop(k)
+else:
     tissue_counts = dna_seq_varlociraptor.samples.groupby("alias").size()
     if tissue_counts["normal"] != tissue_counts["tumor"]:
         raise WorkflowError(

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -1,3 +1,17 @@
+__definitions__:
+  - |
+    def get_events(event_type):
+        if event_type == "somatic_variants":
+          return ["somatic_tumor_high", "somatic_tumor_low"]
+        if event_type == "loh":
+          return ["loh", "loh_or_amplification"]
+  - |
+    def get_description(event_type):
+        if event_type == "somatic_variants":
+          return "somatic variants"
+        if event_type == "loh":
+          return "LOH or amplification of alt allele"
+
 samples: config/samples.tsv
 
 units: config/units.tsv
@@ -129,241 +143,227 @@ calling:
     threshold: 0.05
     local: true
     events:
-      loh_or_amplification:
-        varlociraptor:
-          - loh
-          - loh_or_amplification
-        filter:
-          - loh_relevant
-        sort:
-          - impact
-          - revel
-        desc: |
-          Variants with loss of heterozygosity or strong somatic amplification of the alt allele.
-        labels:
-          event: LOH or amplification of alt allele
-        subcategory: loss of heterozygosity
+      ?for event_type in ["somatic_variants", "loh"]:
+        impact_moderate_novel_high_vaf:
+          varlociraptor:
+            ?for event in get_events(event_type):
+              - ?event
+          filter:
+            - impact_moderate
+            - novel
+            - revel_malign
+            - allele_frequency_high
+          sort:
+            - revel
+            - 'tumor: allele frequency'
+          desc: |
+            ?f"Novel {get_description(event_type)} with moderate impact and high allele frequency."
+          labels:
+            impact: moderate
+            VAF: high
+          subcategory: ?f"{get_description(event_type)} of uncertain significance"
 
-      impact_moderate_novel_high_vaf:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - impact_moderate
-          - novel
-          - revel_malign
-          - allele_frequency_high
-        sort:
-          - revel
-          - 'tumor: allele frequency'
-        desc: |
-          Novel somatic variants with moderate impact and high allele frequency.
-        labels:
-          impact: moderate
-          VAF: high
-        subcategory: somatic variants of uncertain significance
+        impact_moderate_novel_low_vaf:
+          varlociraptor:
+            ?for event in events:
+            - ?event
+          filter:
+            - impact_moderate
+            - novel
+            - revel_malign
+            - allele_frequency_low
+          sort:
+            - 'tumor: allele frequency'
+            - revel
+          desc: |
+            ?"Novel {get_description(event_type)} with moderate impact and low allele frequency."
+          labels:
+            impact: moderate
+            VAF: low
+          subcategory: ?f"{get_description(event_type)} of uncertain significance"
 
-      impact_moderate_novel_low_vaf:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - impact_moderate
-          - novel
-          - revel_malign
-          - allele_frequency_low
-        sort:
-          - 'tumor: allele frequency'
-          - revel
-        desc: |
-          Novel somatic variants with moderate impact and low allele frequency.
-        labels:
-          impact: moderate
-          VAF: low
-        subcategory: somatic variants of uncertain significance
+        impact_high_novel_high_vaf:
+          varlociraptor:
+            ?for event in events:
+            - ?event
+          filter:
+            - impact_high
+            - novel
+            - revel_malign
+            - allele_frequency_high
+          sort:
+            - revel
+            - 'tumor: allele frequency'
+          desc: |
+            ?f"Novel {get_description(event_type)} with high impact and high allele frequency."
+          labels:
+            impact: high
+            VAF: high
+          subcategory: ?f"{get_description(event_type)} of uncertain significance"
 
-      impact_high_novel_high_vaf:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - impact_high
-          - novel
-          - revel_malign
-          - allele_frequency_high
-        sort:
-          - revel
-          - 'tumor: allele frequency'
-        desc: |
-          Novel somatic variants with high impact and high allele frequency.
-        labels:
-          impact: high
-          VAF: high
-        subcategory: somatic variants of uncertain significance
+        impact_high_novel_low_vaf:
+          varlociraptor:
+            ?for event in events:
+            - ?event
+          filter:
+            - impact_high
+            - novel
+            - revel_malign
+            - allele_frequency_low
+          sort:
+            - 'tumor: allele frequency'
+            - revel
+          desc: |
+            ?f"Novel {get_description(event_type)} with high impact and low allele frequency."
+          labels:
+            impact: high
+            VAF: low
+          subcategory: ?f"{get_description(event_type)} of uncertain significance"
 
-      impact_high_novel_low_vaf:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - impact_high
-          - novel
-          - revel_malign
-          - allele_frequency_low
-        sort:
-          - 'tumor: allele frequency'
-          - revel
-        desc: |
-          Novel somatic variants with high impact and low allele frequency.
-        labels:
-          impact: high
-          VAF: low
-        subcategory: somatic variants of uncertain significance
+        pathogenic_risk_factor_drug_response:
+          varlociraptor:
+            ?for event in events:
+            - ?event
+          filter:
+            - pathogenic_risk_factor_drug_response
+          sort:
+            - impact
+            - revel
+            - 'tumor: allele frequency'
+          desc: |
+            ?f"{get_description(event_type)} being pathogenic or risk factor high."
+          labels:
+            clinical significance: pathogenic, risk factor, or drug response
+          subcategory: ?f"known {get_description(event_type)}"
+        
+        splice_variants:
+          varlociraptor:
+            ?for event in events:
+            - ?event
+          filter:
+            - splice_mutation
+            - revel_malign
+            - novel
+          sort:
+            - impact
+            - revel
+          desc: |
+            Somatic splice mutations
+          labels:
+            consequence: splice
+          subcategory: ?f"{get_description(event_type)} of uncertain significance"
 
-      pathogenic_risk_factor_drug_response:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - pathogenic_risk_factor_drug_response
-        sort:
-          - impact
-          - revel
-          - 'tumor: allele frequency'
-        desc: |
-          Somatic variants being pathogenic or risk factor high.
-        labels:
-          clinical significance: pathogenic, risk factor, or drug response
-        subcategory: known somatic variants
-      
-      splice_variants:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - splice_mutation
-          - revel_malign
-          - novel
-        sort:
-          - impact
-          - revel
-        desc: |
-          Somatic splice mutations
-        labels:
-          consequence: splice
-        subcategory: somatic variants of uncertain significance
+        cancer_genes:
+          varlociraptor:
+            ?for event in events:
+            - ?event
+          filter:
+            - cancer_relevant
+            - cancer_genes
+          sort:
+            - impact
+            - revel
+          desc: |
+            Somatic variants affecting known cancer genes with low to high impact.
+          labels:
+            gene set: cancer genes
+          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
-      cancer_genes:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - cancer_relevant
-          - cancer_genes
-        sort:
-          - impact
-          - revel
-        desc: |
-          Somatic variants affecting known cancer genes with low to high impact.
-        labels:
-          gene set: cancer genes
-        subcategory: somatic variants in gene sets and pathways
+        pi3k_pathway:
+          varlociraptor:
+            ?for event in events:
+            - ?event
+          filter:
+            - cancer_relevant
+            - pi3k_pathway
+          sort:
+            - impact
+            - revel
+          desc: |
+            ?f"{get_description(event_type)} affecting PI3K-AKT-mTOR pathway genes, sorted by impact and revel scores while discarding synonymous variants."
+          labels:
+            gene set: PI3K-AKT-mTOR pathway
+          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
-      pi3k_pathway:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - cancer_relevant
-          - pi3k_pathway
-        sort:
-          - impact
-          - revel
-        desc: |
-          Somatic variants affecting PI3K-AKT-mTOR pathway genes, sorted by impact and revel scores while discarding synonymous variants.
-        labels:
-          gene set: PI3K-AKT-mTOR pathway
-        subcategory: somatic variants in gene sets and pathways
+        raf_pathway:
+          varlociraptor:
+            ?for event in events:
+            - ?event
+          filter:
+            - cancer_relevant
+            - raf_pathway
+          sort:
+            - impact
+            - revel
+          desc: |
+            ?f"{get_description(event_type)} affecting RAF-MEK-ERK pathway genes, sorted by impact and revel scores while discarding synonymous variants."
+          labels:
+            gene set: RAF-MEK-ERK pathway
+          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
-      raf_pathway:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - cancer_relevant
-          - raf_pathway
-        sort:
-          - impact
-          - revel
-        desc: |
-          Somatic variants affecting RAF-MEK-ERK pathway genes, sorted by impact and revel scores while discarding synonymous variants.
-        labels:
-          gene set: RAF-MEK-ERK pathway
-        subcategory: somatic variants in gene sets and pathways
+        cell_cycle:
+          varlociraptor:
+            ?for event in events:
+            - ?event
+          filter:
+            - cancer_relevant
+            - cell_cycle
+          sort:
+            - impact
+            - revel
+          desc: |
+            ?f"{get_description(event_type)} affecting cell cycle genes with low to high impact."
+          labels:
+            gene set: cell cycle
+          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
-      cell_cycle:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - cancer_relevant
-          - cell_cycle
-        sort:
-          - impact
-          - revel
-        desc: |
-          Somatic variants affecting cell cycle genes with low to high impact.
-        labels:
-          gene set: cell cycle
-        subcategory: somatic variants in gene sets and pathways
+        dna_damage_response:
+          varlociraptor:
+            ?for event in events:
+            - ?event
+          filter:
+            - cancer_relevant
+            - dna_damage_response
+          sort:
+            - impact
+            - revel
+          desc: |
+            ?f"{get_description(event_type)} affecting dna damage resonse genes with low to high impact."
+          labels:
+            gene set: dna damage response
+          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
-      dna_damage_response:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - cancer_relevant
-          - dna_damage_response
-        sort:
-          - impact
-          - revel
-        desc: |
-          Somatic variants affecting dna damage resonse genes with low to high impact.
-        labels:
-          gene set: dna damage response
-        subcategory: somatic variants in gene sets and pathways
+        g1_topart:
+          varlociraptor:
+            ?for event in events:
+            - ?event
+          filter:
+            - cancer_relevant
+            - g1_topart
+          sort:
+            - impact
+            - revel
+          desc: |
+            ?f"{get_description(event_type)} affecting G1 topart genes with low to high impact."
+          labels:
+            gene set: G1 topart
+          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
-      g1_topart:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - cancer_relevant
-          - g1_topart
-        sort:
-          - impact
-          - revel
-        desc: |
-          Somatic variants affecting G1 topart genes with low to high impact.
-        labels:
-          gene set: G1 topart
-        subcategory: somatic variants in gene sets and pathways
-
-      tyrosine_kinases:
-        varlociraptor:
-          - somatic_tumor_high
-          - somatic_tumor_low
-        filter:
-          - cancer_relevant
-          - tyrosine_kinases
-        sort:
-          - impact
-          - revel
-        desc: |
-          Somatic variants affecting tyrosine kinases genes with low to high impact.
-        labels:
-          gene set: tyrosine kinases
-        subcategory: somatic variants in gene sets and pathways
+        tyrosine_kinases:
+          varlociraptor:
+            ?for event in events:
+            - ?event
+          filter:
+            - cancer_relevant
+            - tyrosine_kinases
+          sort:
+            - impact
+            - revel
+          desc: |
+            ?f"{get_description(event_type)} affecting tyrosine kinases genes with low to high impact."
+          labels:
+            gene set: tyrosine kinases
+          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
 # If calc_consensus_reads is activated duplicates will be merged
 remove_duplicates:

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -1,10 +1,7 @@
 __definitions__:
   - |
     def get_event_types():
-      event_types = ["somatic"]
-      if "normal" in samples["alias"]:
-        event_types += ["loh"]
-      return event_types
+      return ["somatic", "loh"]
   - |
     def get_events(event_type):
         if event_type == "somatic":
@@ -182,7 +179,7 @@ calling:
             - 'tumor: allele frequency'
             - revel
           desc: |
-            ?"Novel {get_description(event_type)} with moderate impact and low allele frequency."
+            ?f"Novel {get_description(event_type)} with moderate impact and low allele frequency."
           labels:
             impact: moderate
             VAF: low

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -165,8 +165,8 @@ calling:
 
         impact_moderate_novel_low_vaf:
           varlociraptor:
-            ?for event in events:
-            - ?event
+            ?for event in get_events(event_type):
+              - ?event
           filter:
             - impact_moderate
             - novel
@@ -184,8 +184,8 @@ calling:
 
         impact_high_novel_high_vaf:
           varlociraptor:
-            ?for event in events:
-            - ?event
+            ?for event in get_events(event_type):
+              - ?event
           filter:
             - impact_high
             - novel
@@ -203,8 +203,8 @@ calling:
 
         impact_high_novel_low_vaf:
           varlociraptor:
-            ?for event in events:
-            - ?event
+            ?for event in get_events(event_type):
+              - ?event
           filter:
             - impact_high
             - novel
@@ -222,8 +222,8 @@ calling:
 
         pathogenic_risk_factor_drug_response:
           varlociraptor:
-            ?for event in events:
-            - ?event
+            ?for event in get_events(event_type):
+              - ?event
           filter:
             - pathogenic_risk_factor_drug_response
           sort:
@@ -238,8 +238,8 @@ calling:
         
         splice_variants:
           varlociraptor:
-            ?for event in events:
-            - ?event
+            ?for event in get_events(event_type):
+              - ?event
           filter:
             - splice_mutation
             - revel_malign
@@ -255,8 +255,8 @@ calling:
 
         cancer_genes:
           varlociraptor:
-            ?for event in events:
-            - ?event
+            ?for event in get_events(event_type):
+              - ?event
           filter:
             - cancer_relevant
             - cancer_genes
@@ -271,8 +271,8 @@ calling:
 
         pi3k_pathway:
           varlociraptor:
-            ?for event in events:
-            - ?event
+            ?for event in get_events(event_type):
+              - ?event
           filter:
             - cancer_relevant
             - pi3k_pathway
@@ -287,8 +287,8 @@ calling:
 
         raf_pathway:
           varlociraptor:
-            ?for event in events:
-            - ?event
+            ?for event in get_events(event_type):
+              - ?event
           filter:
             - cancer_relevant
             - raf_pathway
@@ -303,8 +303,8 @@ calling:
 
         cell_cycle:
           varlociraptor:
-            ?for event in events:
-            - ?event
+            ?for event in get_events(event_type):
+              - ?event
           filter:
             - cancer_relevant
             - cell_cycle
@@ -319,8 +319,8 @@ calling:
 
         dna_damage_response:
           varlociraptor:
-            ?for event in events:
-            - ?event
+            ?for event in get_events(event_type):
+              - ?event
           filter:
             - cancer_relevant
             - dna_damage_response
@@ -335,8 +335,8 @@ calling:
 
         g1_topart:
           varlociraptor:
-            ?for event in events:
-            - ?event
+            ?for event in get_events(event_type):
+              - ?event
           filter:
             - cancer_relevant
             - g1_topart
@@ -351,8 +351,8 @@ calling:
 
         tyrosine_kinases:
           varlociraptor:
-            ?for event in events:
-            - ?event
+            ?for event in get_events(event_type):
+              - ?event
           filter:
             - cancer_relevant
             - tyrosine_kinases

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -183,7 +183,7 @@ calling:
           labels:
             impact: moderate
             VAF: low
-          subcategory: ?f"{get_description(event_type)} of uncertain significance"
+          subcategory: ?f"{get_description(event_type).capitalize()} of uncertain significance"
 
         ?f"{event_type}_impact_high_novel_high_vaf":
           varlociraptor:
@@ -202,7 +202,7 @@ calling:
           labels:
             impact: high
             VAF: high
-          subcategory: ?f"{get_description(event_type)} of uncertain significance"
+          subcategory: ?f"{get_description(event_type).capitalize()} of uncertain significance"
 
         ?f"{event_type}_impact_high_novel_low_vaf":
           varlociraptor:
@@ -221,7 +221,7 @@ calling:
           labels:
             impact: high
             VAF: low
-          subcategory: ?f"{get_description(event_type)} of uncertain significance"
+          subcategory: ?f"{get_description(event_type).capitalize()} of uncertain significance"
 
         ?f"{event_type}_pathogenic_risk_factor_drug_response":
           varlociraptor:
@@ -234,7 +234,7 @@ calling:
             - revel
             - 'tumor: allele frequency'
           desc: |
-            ?f"{get_description(event_type)} being pathogenic or risk factor high."
+            ?f"{get_description(event_type).capitalize()} being pathogenic or risk factor high."
           labels:
             clinical significance: pathogenic, risk factor, or drug response
           subcategory: ?f"known {get_description(event_type)}"
@@ -250,11 +250,10 @@ calling:
           sort:
             - impact
             - revel
-          desc: |
-            Somatic splice mutations
+          desc: ?f"{get_description(event_type).capitalize()} close to splice sites"
           labels:
             consequence: splice
-          subcategory: ?f"{get_description(event_type)} of uncertain significance"
+          subcategory: ?f"{get_description(event_type).capitalize()} of uncertain significance"
 
         ?f"{event_type}_cancer_genes":
           varlociraptor:
@@ -266,11 +265,10 @@ calling:
           sort:
             - impact
             - revel
-          desc: |
-            Somatic variants affecting known cancer genes with low to high impact.
+          desc: ?f"{get_description(event_type).capitalize()} affecting known cancer genes with low to high impact."
           labels:
             gene set: cancer genes
-          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
+          subcategory: ?f"{get_description(event_type).capitalize()} in gene sets and pathways"
 
         ?f"{event_type}_pi3k_pathway":
           varlociraptor:
@@ -283,10 +281,10 @@ calling:
             - impact
             - revel
           desc: |
-            ?f"{get_description(event_type)} affecting PI3K-AKT-mTOR pathway genes, sorted by impact and revel scores while discarding synonymous variants."
+            ?f"{get_description(event_type).capitalize()} affecting PI3K-AKT-mTOR pathway genes, sorted by impact and revel scores while discarding synonymous variants."
           labels:
             gene set: PI3K-AKT-mTOR pathway
-          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
+          subcategory: ?f"{get_description(event_type).capitalize()} in gene sets and pathways"
 
         ?f"{event_type}_raf_pathway":
           varlociraptor:
@@ -299,10 +297,10 @@ calling:
             - impact
             - revel
           desc: |
-            ?f"{get_description(event_type)} affecting RAF-MEK-ERK pathway genes, sorted by impact and revel scores while discarding synonymous variants."
+            ?f"{get_description(event_type).capitalize()} affecting RAF-MEK-ERK pathway genes, sorted by impact and revel scores while discarding synonymous variants."
           labels:
             gene set: RAF-MEK-ERK pathway
-          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
+          subcategory: ?f"{get_description(event_type).capitalize()} in gene sets and pathways"
 
         ?f"{event_type}_cell_cycle":
           varlociraptor:
@@ -315,10 +313,10 @@ calling:
             - impact
             - revel
           desc: |
-            ?f"{get_description(event_type)} affecting cell cycle genes with low to high impact."
+            ?f"{get_description(event_type).capitalize()} affecting cell cycle genes with low to high impact."
           labels:
             gene set: cell cycle
-          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
+          subcategory: ?f"{get_description(event_type).capitalize()} in gene sets and pathways"
 
         ?f"{event_type}_dna_damage_response":
           varlociraptor:
@@ -331,7 +329,7 @@ calling:
             - impact
             - revel
           desc: |
-            ?f"{get_description(event_type)} affecting dna damage resonse genes with low to high impact."
+            ?f"{get_description(event_type).capitalize()} affecting dna damage resonse genes with low to high impact."
           labels:
             gene set: dna damage response
           subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
@@ -347,7 +345,7 @@ calling:
             - impact
             - revel
           desc: |
-            ?f"{get_description(event_type)} affecting G1 topart genes with low to high impact."
+            ?f"{get_description(event_type).capitalize()} affecting G1 topart genes with low to high impact."
           labels:
             gene set: G1 topart
           subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
@@ -363,10 +361,10 @@ calling:
             - impact
             - revel
           desc: |
-            ?f"{get_description(event_type)} affecting tyrosine kinases genes with low to high impact."
+            ?f"{get_description(event_type).capitalize()} affecting tyrosine kinases genes with low to high impact."
           labels:
             gene set: tyrosine kinases
-          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
+          subcategory: ?f"{get_description(event_type).capitalize()} in gene sets and pathways"
 
 # If calc_consensus_reads is activated duplicates will be merged
 remove_duplicates:

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -1,13 +1,19 @@
 __definitions__:
   - |
+    def get_event_types():
+      event_types = ["somatic"]
+      if "normal" in samples["alias"]:
+        event_types += ["loh"]
+      return event_types
+  - |
     def get_events(event_type):
-        if event_type == "somatic_variants":
+        if event_type == "somatic":
           return ["somatic_tumor_high", "somatic_tumor_low"]
         if event_type == "loh":
           return ["loh", "loh_or_amplification"]
   - |
     def get_description(event_type):
-        if event_type == "somatic_variants":
+        if event_type == "somatic":
           return "somatic variants"
         if event_type == "loh":
           return "LOH or amplification of alt allele"
@@ -143,8 +149,8 @@ calling:
     threshold: 0.05
     local: true
     events:
-      ?for event_type in ["somatic_variants", "loh"]:
-        impact_moderate_novel_high_vaf:
+      ?for event_type in get_event_types():
+        ?f"{event_type}_impact_moderate_novel_high_vaf":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event
@@ -163,7 +169,7 @@ calling:
             VAF: high
           subcategory: ?f"{get_description(event_type)} of uncertain significance"
 
-        impact_moderate_novel_low_vaf:
+        ?f"{event_type}_impact_moderate_novel_low_vaf":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event
@@ -182,7 +188,7 @@ calling:
             VAF: low
           subcategory: ?f"{get_description(event_type)} of uncertain significance"
 
-        impact_high_novel_high_vaf:
+        ?f"{event_type}_impact_high_novel_high_vaf":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event
@@ -201,7 +207,7 @@ calling:
             VAF: high
           subcategory: ?f"{get_description(event_type)} of uncertain significance"
 
-        impact_high_novel_low_vaf:
+        ?f"{event_type}_impact_high_novel_low_vaf":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event
@@ -220,7 +226,7 @@ calling:
             VAF: low
           subcategory: ?f"{get_description(event_type)} of uncertain significance"
 
-        pathogenic_risk_factor_drug_response:
+        ?f"{event_type}_pathogenic_risk_factor_drug_response":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event
@@ -236,7 +242,7 @@ calling:
             clinical significance: pathogenic, risk factor, or drug response
           subcategory: ?f"known {get_description(event_type)}"
         
-        splice_variants:
+        ?f"{event_type}_splice_variants":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event
@@ -253,7 +259,7 @@ calling:
             consequence: splice
           subcategory: ?f"{get_description(event_type)} of uncertain significance"
 
-        cancer_genes:
+        ?f"{event_type}_cancer_genes":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event
@@ -269,7 +275,7 @@ calling:
             gene set: cancer genes
           subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
-        pi3k_pathway:
+        ?f"{event_type}_pi3k_pathway":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event
@@ -285,7 +291,7 @@ calling:
             gene set: PI3K-AKT-mTOR pathway
           subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
-        raf_pathway:
+        ?f"{event_type}_raf_pathway":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event
@@ -301,7 +307,7 @@ calling:
             gene set: RAF-MEK-ERK pathway
           subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
-        cell_cycle:
+        ?f"{event_type}_cell_cycle":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event
@@ -317,7 +323,7 @@ calling:
             gene set: cell cycle
           subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
-        dna_damage_response:
+        ?f"{event_type}_dna_damage_response":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event
@@ -333,7 +339,7 @@ calling:
             gene set: dna damage response
           subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
-        g1_topart:
+        ?f"{event_type}_g1_topart":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event
@@ -349,7 +355,7 @@ calling:
             gene set: G1 topart
           subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
 
-        tyrosine_kinases:
+        ?f"{event_type}_tyrosine_kinases":
           varlociraptor:
             ?for event in get_events(event_type):
               - ?event

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -1,8 +1,5 @@
 __definitions__:
   - |
-    def get_event_types():
-      return ["somatic", "loh"]
-  - |
     def get_events(event_type):
         if event_type == "somatic":
           return ["somatic_tumor_high", "somatic_tumor_low"]
@@ -146,11 +143,10 @@ calling:
     threshold: 0.05
     local: true
     events:
-      ?for event_type in get_event_types():
+      ?for event_type in ["somatic", "loh"]:
         ?f"{event_type}_impact_moderate_novel_high_vaf":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - impact_moderate
             - novel
@@ -168,8 +164,7 @@ calling:
 
         ?f"{event_type}_impact_moderate_novel_low_vaf":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - impact_moderate
             - novel
@@ -187,8 +182,7 @@ calling:
 
         ?f"{event_type}_impact_high_novel_high_vaf":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - impact_high
             - novel
@@ -206,8 +200,7 @@ calling:
 
         ?f"{event_type}_impact_high_novel_low_vaf":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - impact_high
             - novel
@@ -225,8 +218,7 @@ calling:
 
         ?f"{event_type}_pathogenic_risk_factor_drug_response":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - pathogenic_risk_factor_drug_response
           sort:
@@ -241,8 +233,7 @@ calling:
         
         ?f"{event_type}_splice_variants":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - splice_mutation
             - revel_malign
@@ -257,8 +248,7 @@ calling:
 
         ?f"{event_type}_cancer_genes":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - cancer_relevant
             - cancer_genes
@@ -272,8 +262,7 @@ calling:
 
         ?f"{event_type}_pi3k_pathway":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - cancer_relevant
             - pi3k_pathway
@@ -288,8 +277,7 @@ calling:
 
         ?f"{event_type}_raf_pathway":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - cancer_relevant
             - raf_pathway
@@ -304,8 +292,7 @@ calling:
 
         ?f"{event_type}_cell_cycle":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - cancer_relevant
             - cell_cycle
@@ -320,8 +307,7 @@ calling:
 
         ?f"{event_type}_dna_damage_response":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - cancer_relevant
             - dna_damage_response
@@ -336,8 +322,7 @@ calling:
 
         ?f"{event_type}_g1_topart":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - cancer_relevant
             - g1_topart
@@ -352,8 +337,7 @@ calling:
 
         ?f"{event_type}_tyrosine_kinases":
           varlociraptor:
-            ?for event in get_events(event_type):
-              - ?event
+            ?get_events(event_type)
           filter:
             - cancer_relevant
             - tyrosine_kinases

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -158,9 +158,10 @@ calling:
           desc: |
             ?f"Novel {get_description(event_type)} with moderate impact and high allele frequency."
           labels:
+            callset: VUS
             impact: moderate
             VAF: high
-          subcategory: ?f"{get_description(event_type)} of uncertain significance"
+          subcategory: ?get_description(event_type)
 
         ?f"{event_type}_impact_moderate_novel_low_vaf":
           varlociraptor:
@@ -176,9 +177,10 @@ calling:
           desc: |
             ?f"Novel {get_description(event_type)} with moderate impact and low allele frequency."
           labels:
+            callset: VUS
             impact: moderate
             VAF: low
-          subcategory: ?f"{get_description(event_type).capitalize()} of uncertain significance"
+          subcategory: ?get_description(event_type)
 
         ?f"{event_type}_impact_high_novel_high_vaf":
           varlociraptor:
@@ -194,9 +196,10 @@ calling:
           desc: |
             ?f"Novel {get_description(event_type)} with high impact and high allele frequency."
           labels:
+            callset: VUS
             impact: high
             VAF: high
-          subcategory: ?f"{get_description(event_type).capitalize()} of uncertain significance"
+          subcategory: ?get_description(event_type)
 
         ?f"{event_type}_impact_high_novel_low_vaf":
           varlociraptor:
@@ -212,9 +215,10 @@ calling:
           desc: |
             ?f"Novel {get_description(event_type)} with high impact and low allele frequency."
           labels:
+            callset: VUS
             impact: high
             VAF: low
-          subcategory: ?f"{get_description(event_type).capitalize()} of uncertain significance"
+          subcategory: ?get_description(event_type)
 
         ?f"{event_type}_pathogenic_risk_factor_drug_response":
           varlociraptor:
@@ -226,10 +230,12 @@ calling:
             - revel
             - 'tumor: allele frequency'
           desc: |
-            ?f"{get_description(event_type).capitalize()} being pathogenic or risk factor high."
+            ?f"{get_description(event_type)} being pathogenic or risk factor high."
           labels:
-            clinical significance: pathogenic, risk factor, or drug response
-          subcategory: ?f"known {get_description(event_type)}"
+            callset: pathogenic, risk factor, or drug response
+            impact: low, moderate, high
+            VAF: any
+          subcategory: ?get_description(event_type)
         
         ?f"{event_type}_splice_variants":
           varlociraptor:
@@ -241,10 +247,12 @@ calling:
           sort:
             - impact
             - revel
-          desc: ?f"{get_description(event_type).capitalize()} close to splice sites"
+          desc: ?f"{get_description(event_type)} close to splice sites"
           labels:
-            consequence: splice
-          subcategory: ?f"{get_description(event_type).capitalize()} of uncertain significance"
+            callset: splice site variants
+            impact: any
+            VAF: any
+          subcategory: ?get_description(event_type)
 
         ?f"{event_type}_cancer_genes":
           varlociraptor:
@@ -255,10 +263,12 @@ calling:
           sort:
             - impact
             - revel
-          desc: ?f"{get_description(event_type).capitalize()} affecting known cancer genes with low to high impact."
+          desc: ?f"{get_description(event_type)} affecting known cancer genes with low to high impact."
           labels:
-            gene set: cancer genes
-          subcategory: ?f"{get_description(event_type).capitalize()} in gene sets and pathways"
+            callset: cancer genes
+            impact: low, moderate, high
+            VAF: any
+          subcategory: ?get_description(event_type)
 
         ?f"{event_type}_pi3k_pathway":
           varlociraptor:
@@ -270,10 +280,12 @@ calling:
             - impact
             - revel
           desc: |
-            ?f"{get_description(event_type).capitalize()} affecting PI3K-AKT-mTOR pathway genes, sorted by impact and revel scores while discarding synonymous variants."
+            ?f"{get_description(event_type)} affecting PI3K-AKT-mTOR pathway genes, sorted by impact and revel scores while discarding synonymous variants."
           labels:
-            gene set: PI3K-AKT-mTOR pathway
-          subcategory: ?f"{get_description(event_type).capitalize()} in gene sets and pathways"
+            callset: PI3K-AKT-mTOR pathway
+            impact: low, moderate, high
+            VAF: any
+          subcategory: ?get_description(event_type)
 
         ?f"{event_type}_raf_pathway":
           varlociraptor:
@@ -285,10 +297,12 @@ calling:
             - impact
             - revel
           desc: |
-            ?f"{get_description(event_type).capitalize()} affecting RAF-MEK-ERK pathway genes, sorted by impact and revel scores while discarding synonymous variants."
+            ?f"{get_description(event_type)} affecting RAF-MEK-ERK pathway genes, sorted by impact and revel scores while discarding synonymous variants."
           labels:
-            gene set: RAF-MEK-ERK pathway
-          subcategory: ?f"{get_description(event_type).capitalize()} in gene sets and pathways"
+            callset: RAF-MEK-ERK pathway
+            impact: low, moderate, high
+            VAF: any
+          subcategory: ?get_description(event_type)
 
         ?f"{event_type}_cell_cycle":
           varlociraptor:
@@ -300,10 +314,12 @@ calling:
             - impact
             - revel
           desc: |
-            ?f"{get_description(event_type).capitalize()} affecting cell cycle genes with low to high impact."
+            ?f"{get_description(event_type)} affecting cell cycle genes with low to high impact."
           labels:
-            gene set: cell cycle
-          subcategory: ?f"{get_description(event_type).capitalize()} in gene sets and pathways"
+            callset: cell cycle
+            impact: low, moderate, high
+            VAF: any
+          subcategory: ?get_description(event_type)
 
         ?f"{event_type}_dna_damage_response":
           varlociraptor:
@@ -315,10 +331,12 @@ calling:
             - impact
             - revel
           desc: |
-            ?f"{get_description(event_type).capitalize()} affecting dna damage resonse genes with low to high impact."
+            ?f"{get_description(event_type)} affecting dna damage resonse genes with low to high impact."
           labels:
-            gene set: dna damage response
-          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
+            callset: dna damage response
+            impact: low, moderate, high
+            VAF: any
+          subcategory: ?get_description(event_type)
 
         ?f"{event_type}_g1_topart":
           varlociraptor:
@@ -330,10 +348,12 @@ calling:
             - impact
             - revel
           desc: |
-            ?f"{get_description(event_type).capitalize()} affecting G1 topart genes with low to high impact."
+            ?f"{get_description(event_type)} affecting G1 topart genes with low to high impact."
           labels:
-            gene set: G1 topart
-          subcategory: ?f"{get_description(event_type)} in gene sets and pathways"
+            callset: G1 topart
+            impact: low, moderate, high
+            VAF: any
+          subcategory: ?get_description(event_type)
 
         ?f"{event_type}_tyrosine_kinases":
           varlociraptor:
@@ -345,10 +365,12 @@ calling:
             - impact
             - revel
           desc: |
-            ?f"{get_description(event_type).capitalize()} affecting tyrosine kinases genes with low to high impact."
+            ?f"{get_description(event_type)} affecting tyrosine kinases genes with low to high impact."
           labels:
-            gene set: tyrosine kinases
-          subcategory: ?f"{get_description(event_type).capitalize()} in gene sets and pathways"
+            callset: tyrosine kinases
+            impact: low, moderate, high
+            VAF: any
+          subcategory: ?get_description(event_type)
 
 # If calc_consensus_reads is activated duplicates will be merged
 remove_duplicates:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,9 +1,8 @@
-import yaml
-
+from yte import process_yaml
 
 # load defaults for the full dna-seq-varlociraptor pipeline
 with open(workflow.source_path("../resources/config/default.yaml")) as infile:
-    config = yaml.load(infile, Loader=yaml.SafeLoader)
+    config = process_yaml(infile)
 
 
 config["calling"]["scenario"] = workflow.source_path(


### PR DESCRIPTION
This PR introduces separate callsets for LOH.
Therefore the default config file has been extended and will be parsed by `yte`.