### PR TITLE
fix: allow somatic-normal mutations above VAF 0.5

### DIFF
--- a/workflow/resources/config/scenario.yaml
+++ b/workflow/resources/config/scenario.yaml
@@ -53,8 +53,7 @@ species:
 
   events:
     somatic_tumor_high: "normal:0.0 & tumor:[0.1,1.0]"
-    somatic_normal: "normal:[0.05,0.5[ & tumor:[0.0,1.0]"
-    somatic_normal_or_ctc: "normal:]0.0,0.05[ & tumor:[0.0,1.0]"
+    somatic_normal_or_ctc: "(normal:]0.0,0.5[ | normal:]0.5,1.0[) & tumor:[0.0,1.0]"
     loh: "normal:0.5 & tumor:1.0"
     loh_or_amplification: "normal:0.5 & tumor:[0.9,1.0["
     germline: "(normal:0.5 & tumor:[0.0,0.9[) | (normal:1.0 & tumor:[0.0,1.0])"


### PR DESCRIPTION
This fixes an issue with VAFs of  e.g. 0.9 in the normal, which would have otherwise erroneously driven the system towards calling an LOH with VAF 0.5 in the normal if the difference of 0.1 in the VAF cannot be explained by MAPQ.