### PR TITLE
fix: update parameters and callsets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Lint workflow
-      uses: snakemake/snakemake-github-action@v1.24.0
+      uses: snakemake/snakemake-github-action@v1.25.0
       with:
         directory: .
         snakefile: workflow/Snakefile
@@ -40,42 +40,46 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Test workflow (tumor/normal)
-      uses: snakemake/snakemake-github-action@v1.24.0
+      uses: snakemake/snakemake-github-action@v1.25.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-tumor_normal/config.yaml --use-conda --show-failed-logs --cores 3 --conda-cleanup-pkgs cache"
+        show-disk-usage-on-error: true
 
     - name: Test report
-      uses: snakemake/snakemake-github-action@v1.24.0
+      uses: snakemake/snakemake-github-action@v1.25.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-tumor_normal/config.yaml --report report.zip"
 
     - name: Test workflow (tumor/normal, ffpe)
-      uses: snakemake/snakemake-github-action@v1.24.0
+      uses: snakemake/snakemake-github-action@v1.25.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-tumor_normal_ffpe/config.yaml --use-conda --show-failed-logs --cores 3 --conda-cleanup-pkgs cache --all-temp"
         stagein: |
           rm -rf .test/results
+        show-disk-usage-on-error: true
 
     - name: Test workflow (tumor only)
-      uses: snakemake/snakemake-github-action@v1.24.0
+      uses: snakemake/snakemake-github-action@v1.25.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-tumor_only/config.yaml --use-conda --show-failed-logs --cores 3 --conda-cleanup-pkgs cache --all-temp"
         stagein: |
           rm -rf .test/results
+        show-disk-usage-on-error: true
 
     - name: Test workflow (tumor only, ffpe)
-      uses: snakemake/snakemake-github-action@v1.24.0
+      uses: snakemake/snakemake-github-action@v1.25.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-tumor_only_ffpe/config.yaml --use-conda --show-failed-logs --cores 3 --conda-cleanup-pkgs cache --all-temp"
         stagein: |
           rm -rf .test/results
+        show-disk-usage-on-error: true

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -48,9 +48,9 @@ params:
     # which might be misleading because all reads of an amplicon have the same start
     # position, strand etc. (--omit-strand-bias, --omit-read-position-bias, 
     # --omit-softclip-bias, --omit-read-orientation-bias).
-    call: ""
+    call: "--omit-read-position-bias"
     # Add extra arguments for varlociraptor preprocess. By default, we limit the depth to 200.
     # Increase this value for panel sequencing!
-    preprocess: "--max-depth 200"
+    preprocess: "--max-depth 30000"
   freebayes:
     min_alternate_fraction: 0.01 # Reduce for calling variants with lower VAFs

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -6,7 +6,7 @@ module dna_seq_varlociraptor:
         github(
             "snakemake-workflows/dna-seq-varlociraptor",
             path="workflow/Snakefile",
-            tag="v5.0.1",
+            tag="v5.1.0",
         )
     config:
         config

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -6,7 +6,7 @@ module dna_seq_varlociraptor:
         github(
             "snakemake-workflows/dna-seq-varlociraptor",
             path="workflow/Snakefile",
-            tag="v4.0.1",
+            tag="v4.1.0",
         )
     config:
         config

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -6,7 +6,7 @@ module dna_seq_varlociraptor:
         github(
             "snakemake-workflows/dna-seq-varlociraptor",
             path="workflow/Snakefile",
-            tag="v4.1.0",
+            tag="v5.0.1",
         )
     config:
         config

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -108,13 +108,13 @@ calling:
     novel: >-
       not (ID and ID.startswith('rs'))
     pathogenic_risk_factor_drug_response: >-
-      (not {'risk_factor', 'likely_pathogenic','pathogenic', 'drug_response'}.isdisjoint(ANN['CLIN_SIG'])) and 
-      (ANN['IMPACT'] in {'LOW', 'MODERATE', 'HIGH'})
+      (not {'risk_factor','pathogenic', 'drug_response'}.isdisjoint(ANN['CLIN_SIG'])) and 
+      (ANN['IMPACT'] in {'LOW', 'MODERATE', 'HIGH'}) and (ANN['REVEL'] is NA or ANN['REVEL'] >= 0.5)
     potentially_pathogenic: >-
       (ANN['IMPACT'] in {'LOW', 'MODERATE', 'HIGH'}) and (
       ((not {'risk_factor', 'pathogenic', 'drug_response'}.isdisjoint(ANN['CLIN_SIG'])) and ANN['REVEL'] is not NA and ANN['REVEL'] < 0.5) or (
-      'likely_pathogenic' in ANN['CLIN_SIG'] and not (
-      (not {'risk_factor', 'pathogenic', 'drug_response'}.isdisjoint(ANN['CLIN_SIG'])) and ANN['REVEL'] is NA or ANN['REVEL'] >= 0.5)))
+      'likely_pathogenic' in ANN['CLIN_SIG'] and (
+      ({'risk_factor', 'pathogenic', 'drug_response'}.isdisjoint(ANN['CLIN_SIG'])) and (ANN['REVEL'] is NA or ANN['REVEL'] >= 0.5))))
     loh_relevant: >-
       ANN['IMPACT'] != 'LOW' and ANN['IMPACT'] != 'MODIFIER' and
       not (set(["benign", "likely benign"]) > set(ANN['CLIN_SIG']) and "benign" in ANN['CLIN_SIG'])

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -108,7 +108,7 @@ calling:
     novel: >-
       not (ID and ID.startswith('rs'))
     pathogenic_risk_factor_drug_response: >-
-      (not {'risk_factor', 'pathogenic', 'drug_response'}.isdisjoint(ANN['CLIN_SIG'])) and 
+      (not {'risk_factor', 'likely_pathogenic','pathogenic', 'drug_response'}.isdisjoint(ANN['CLIN_SIG'])) and 
       (ANN['IMPACT'] in {'LOW', 'MODERATE', 'HIGH'})
     potentially_pathogenic: >-
       (ANN['IMPACT'] in {'LOW', 'MODERATE', 'HIGH'}) and (

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -391,8 +391,6 @@ annotations:
         # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
         - LoFtool
         - REVEL
-  spliceai:
-    activate: true
 
 params:
   cutadapt: ""

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -407,9 +407,9 @@ params:
     # which might be misleading because all reads of an amplicon have the sample start
     # position, strand etc. (--omit-strand-bias, --omit-read-position-bias,
     # --omit-softclip-bias, --omit-read-orientation-bias).
-    call: ""
+    call: "--omit-read-position-bias"
     # Add extra arguments for varlociraptor preprocess. By default, we limit the depth to 200.
     # Increase this value for panel sequencing!
-    preprocess: "--max-depth 200"
+    preprocess: "--max-depth 30000"
   freebayes:
     min_alternate_fraction: 0.05 # Reduce for calling variants with lower VAFs

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -29,7 +29,7 @@ ref:
   # Ensembl species name
   species: homo_sapiens
   # Ensembl release
-  release: 109
+  release: 110
   # Genome build
   build: GRCh38
 
@@ -377,12 +377,22 @@ annotations:
   vep:
     # Consider removing --everything if VEP is slow for you (e.g. for WGS),
     # and think carefully about which annotations you need.
-    params: --everything --check_existing
-    plugins:
-      # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
-      # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
-      - LoFtool
-      - REVEL
+    candidate_calls:
+      params: --everything --check_existing
+      plugins:
+        # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
+        # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
+        - LoFtool
+        - REVEL
+    final_calls:
+      params: --everything --check_existing
+      plugins:
+        # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
+        # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
+        - LoFtool
+        - REVEL
+  spliceai:
+    activate: true
 
 params:
   cutadapt: ""

--- a/workflow/resources/config/scenario.yaml
+++ b/workflow/resources/config/scenario.yaml
@@ -61,7 +61,7 @@ species:
     loh_or_amplification: "normal:0.5 & tumor:[0.9,1.0["
     germline: "(normal:0.5 & tumor:[0.0,0.9[) | (normal:1.0 & tumor:[0.0,1.0])"
     ?if is_ffpe:
-      ffpe_artifact: "($ffpe_subst) & tumor:]0.0,0.05["
+      ffpe_artifact: "normal:0.0 & (($ffpe_subst) & tumor:]0.0,0.05[)"
       somatic_tumor_low: "normal:0.0 & ((($ffpe_subst) & tumor:]0.05,0.1[) | (!($ffpe_subst) & tumor:]0.0,0.1[))"
     ?else:
       somatic_tumor_low: "normal:0.0 & tumor:]0.0,0.1["
@@ -83,7 +83,7 @@ species:
     somatic_tumor_high: "normal:0.0 & tumor:[0.1,1.0]"
     germline: "(normal:0.5 & tumor:0.5) | (normal:1.0 & tumor:1.0)"
     ?if is_ffpe:
-      ffpe_artifact: "($ffpe_subst) & tumor:]0.0,0.05["
+      ffpe_artifact: "normal:0.0 & (($ffpe_subst) & tumor:]0.0,0.05[)"
       somatic_tumor_low: "normal:0.0 & ((($ffpe_subst) & tumor:]0.05,0.1[) | (!($ffpe_subst) & tumor:]0.0,0.1[))"
     ?else:
       somatic_tumor_low: "normal:0.0 & tumor:]0.0,0.1["

--- a/workflow/resources/config/scenario.yaml
+++ b/workflow/resources/config/scenario.yaml
@@ -11,14 +11,20 @@ __definitions__:
     samples = params.samples.set_index("alias")
     if "ffpe" not in samples.columns:
       samples["ffpe"] = pd.NA
-  - sex = samples.loc["tumor", "sex"]
+  - sex = samples.loc[["tumor"], "sex"]
   - |
-    if pd.isna(sex) or sex not in ["male", "female"]:
-        raise ValueError(f"Unsupported sex in sample sheet (also ensure that sample sheet is entirely tab separated): {sex}")
-  - is_ffpe = samples.loc["tumor", "ffpe"]
+    if pd.isna(sex).any() or len(sex.unique()) != 1 or sex.iloc[0] not in ["male", "female"]:
+      raise ValueError(f"Unsupported sex in sample sheet (also ensure that sample sheet is entirely tab separated): {sex}")
+  - is_ffpe = samples.loc[["tumor"], "ffpe"].all()
+  - |
+    if len(samples.loc[["tumor"], "ffpe"].unique()) != 1:
+      raise ValueError(f"All samples within a group must to be either ffpe or not.")
+  - |
+    if len(samples.loc[["tumor"], "purity"].unique()) != 1:
+      raise ValueError(f"All samples within a group need to have the same purity.")
   - |
     def contamination():
-      return 1.0 - float(samples.loc["tumor", "purity"])
+      return 1.0 - float(samples.loc[["tumor"], "purity"].iloc[0])
 
 species:
   heterozygosity: 0.001
@@ -41,7 +47,7 @@ species:
 ?if "normal" in samples.index:
   samples:
     tumor:
-      sex: ?sex
+      sex: ?sex.iloc[0]
       somatic-effective-mutation-rate: 1e-6
       inheritance:
         clonal:
@@ -51,7 +57,7 @@ species:
         by: normal
         fraction: ?contamination()
     normal:
-      sex: ?sex
+      sex: ?sex.iloc[0]
       somatic-effective-mutation-rate: 1e-6
 
   events:
@@ -71,13 +77,13 @@ species:
     tumor:
       resolution: 0.01
       universe: "[0.0,1.0]"
-      sex: ?sex
+      sex: ?sex.iloc[0]
       contamination:
         by: normal
         fraction: ?contamination()
     normal:
       universe: "0.0 | 0.5 | 1.0"
-      sex: ?sex
+      sex: ?sex.iloc[0]
 
   events:
     somatic_tumor_high: "normal:0.0 & tumor:[0.1,1.0]"


### PR DESCRIPTION
As we use panel data having high coverage for the mtb the preconfigured max read depth for varlociraptor preprocess was to low. To get a correct estimation the max-depth has been set to `30000` in the `config.yaml`.

Also considering the read position bias lead to missing variants in the past and therefore will be omitted.