### PR TITLE
fix: remove custom paths

### DIFF
--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -480,8 +480,8 @@ annotations:
         # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
         - LoFtool
         - REVEL
-        - SpliceAI,snv=/home/moelder/resources/SpliceAI/spliceai_scores.raw.snv.hg38.vcf.gz,indel=/home/moelder/resources/SpliceAI/spliceai_scores.raw.indel.hg38.vcf.gz
-        - AlphaMissense,file=/home/moelder/resources/AlphaMissense/AlphaMissense_hg38.tsv.gz
+        # - SpliceAI,snv=<path/to/spliceai_scores.raw.snv.hg38.vcf.gz>,indel=<path/to/spliceai_scores.raw.indel.hg38.vcf.gz
+        # - AlphaMissense,file=<path/to/AlphaMissense_hg38.tsv.gz>
 
 params:
   cutadapt: ""

--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -481,7 +481,7 @@ annotations:
         - LoFtool
         - REVEL
         # - SpliceAI,snv=<path/to/spliceai_scores.raw.snv.hg38.vcf.gz>,indel=<path/to/spliceai_scores.raw.indel.hg38.vcf.gz
-        # - AlphaMissense,file=<path/to/AlphaMissense_hg38.tsv.gz>
+        - AlphaMissense
 
 params:
   cutadapt: ""


### PR DESCRIPTION
In an earlier commit custom paths became part of the default.yaml.
I am uncertain how to handle this as SpliceAI and AlphaMissense became mandatory for this configuration due to the `likely_high_relevance`-event which uses scores from both plugins for filtering.
Both plugins require manually downloaded files for annotation.

In case of AlphaMissense the required file is hosted on zenodo which we could automatically download.
For SpliceAI scores are hosted by Illumina requiring a login.

Edit: Automatic download has been added in dna-seq-varlociraptor (https://github.com/snakemake-workflows/dna-seq-varlociraptor/pull/307/files). Still, there is no solution for SpliceAI