### PR TITLE
fix: fix filter condition

### DIFF
--- a/workflow/resources/config/default.yaml
+++ b/workflow/resources/config/default.yaml
@@ -105,7 +105,7 @@ calling:
     candidates: >-
       not any(
         (consequence in set(['intergenic variant', 'upstream_gene_variant', 'downstream_gene_variant']))
-        for consequence in ANN['Consequence'].split("&")
+        for consequence in ANN['Consequence']
       ) and
       not ('intron_variant' in ANN['Consequence'] and not 'splice' in ANN['Consequence'])
     af_highly_relevant: >-


### PR DESCRIPTION
The varlociraptor workflow has been updated to vembrane 2.0.
There was a breaking change handling the Consequences of the annotation field internally which causes the workflow to fail when applying `.split("&")` on `ANN["Consequence"]`. This can be fixed by dropping the split-call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variant consequence filtering logic to correctly evaluate filtering conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->