### PR TITLE
perf: bump dna-seq-varlociraptor to v6.5.1 

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -6,7 +6,7 @@ module dna_seq_varlociraptor:
         github(
             "snakemake-workflows/dna-seq-varlociraptor",
             path="workflow/Snakefile",
-            tag="v6.4.2",
+            tag="v6.5.1",
         )
     config:
         config


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dna-seq-varlociraptor Snakefile version from v6.4.2 to v6.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->